### PR TITLE
Fix for Missing variable declaration

### DIFF
--- a/tests/text/repeat.test.js
+++ b/tests/text/repeat.test.js
@@ -23,7 +23,7 @@ describe('FLEX text.repeat Integration Tests', () => {
     });
 
 	test('Text function: repeat', async () => {
-		res = await graph.query("RETURN flex.text.repeat('A', 3) AS res");
+		const res = await graph.query("RETURN flex.text.repeat('A', 3) AS res");
         expect(res.data[0]['res']).toBe('AAA');
 
         expect(repeatModule.repeat('A', 3)).toBe('AAA');


### PR DESCRIPTION
To fix this, `res` should be explicitly declared as a local variable in the test where it is used. This avoids creating or mutating a global and makes the variable’s scope clear. The fix should not change existing functionality; only the declaration is missing.

The best fix is to add `const` (or `let`) before `res` on line 26 within the `test('Text function: repeat', ...)` block, because `res` is assigned once and not reassigned. That will make `res` a block‑scoped local variable in that test. No additional imports or helper methods are needed, and no other lines must change.

Concretely, in `tests/text/repeat.test.js`, replace line 26:

```js
26: 		res = await graph.query("RETURN flex.text.repeat('A', 3) AS res");
```

with:

```js
26: 		const res = await graph.query("RETURN flex.text.repeat('A', 3) AS res");
```

This preserves behavior and removes the implicit global.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
 
 **PR Summary by Typo**
------------

#### Overview
This PR addresses a missing variable declaration in a test file, ensuring proper variable scope and preventing potential errors.

#### Key Changes
- Added `const` keyword to the `res` variable declaration in `tests/text/repeat.test.js`.

#### Work Breakdown

| Category | Lines Changed |
|----------|---------------|
| Rework   | 1 (100.0%)    |
| Total Changes | 1         | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>