### PR TITLE
exp-algo: degree centrality

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -115,6 +115,7 @@ Low-level bitwise operations on integers.
 |----------|-------------|
 | [exp.louvain](./exp-algo/louvain.md) | Louvain community detection (modularity optimization) |
 | [exp.leiden](./exp-algo/leiden.md) | Leiden-style community detection (Louvain + refinement) |
+| [exp.degreeCentrality](./exp-algo/degreeCentrality.md) | Degree centrality (undirected; returns degree and normalized degree) |
 
 ## Common Use Cases
 

--- a/docs/exp-algo/degreeCentrality.md
+++ b/docs/exp-algo/degreeCentrality.md
@@ -1,0 +1,55 @@
+# exp.degreeCentrality (Experimental)
+
+## Description
+Compute **degree centrality** for a set of nodes.
+
+**Warning:** This function is **experimental**.
+- The API, behavior, and performance characteristics may change between releases.
+- It is intended for exploration and prototyping, not as a stable production API.
+
+This implementation runs inside FalkorDB’s UDF runtime and uses `graph.traverse` to build an in-memory adjacency representation of the supplied node set.
+
+**Important:** Edges discovered via traversal are treated as **undirected** (symmetrized), similar to `exp.louvain` and `exp.leiden`.
+
+## Syntax
+```cypher
+flex.exp.degreeCentrality({nodes: nodes})
+```
+
+## Parameters
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `nodes` | `list<node>` | Yes | The set of nodes to analyze. Typically provided via `collect(n)`. |
+| `direction` | `string \| list<string>` | No | Which traversal direction(s) to use when building adjacency. Common values: `'incoming'`, `'outgoing'`, `'both'`. Default: `'both'`. |
+| `maxEdgesPerNode` | `integer` | No | Safety cap on how many edges to scan per node when building adjacency. Default: `Infinity`. |
+| `normalized` | `boolean` | No | When `true`, also returns normalized degree (divide by `n-1`). Default: `true`. |
+| `debug` | `boolean` | No | When `true`, returns additional debug information about adjacency building. Default: `false`. |
+
+## Returns
+**Type:** `map`
+
+A map with the following keys:
+- `n` (`integer`): number of input nodes.
+- `maxDegree` (`integer`): maximum degree over the input node set.
+- `degree` (`map`): mapping from `nodeId -> degree`.
+- `weightedDegree` (`map`): mapping from `nodeId -> sum(weights)`.
+- `normalized` (`map`, optional): mapping from `nodeId -> degree/(n-1)` (only when `normalized: true`).
+- `debug` (`map`, optional): only present when `debug: true`.
+
+## Example
+```cypher
+// Compute degree centrality for all nodes with label N
+MATCH (n:N)
+WITH n ORDER BY ID(n)
+WITH collect(n) AS nodes
+RETURN flex.exp.degreeCentrality({nodes: nodes}) AS res;
+```
+
+## Notes
+- **Edge weights:** `weightedDegree` uses relationship property `weight` when present; otherwise it defaults to `1`.
+- **Performance:** requires building an in-memory adjacency structure; prefer running it on a bounded subgraph.
+
+## See Also
+- [exp.louvain](./louvain.md)
+- [exp.leiden](./leiden.md)
+- [docs/README.md](../README.md)

--- a/src/exp-algo/degreeCentrality.js
+++ b/src/exp-algo/degreeCentrality.js
@@ -1,0 +1,117 @@
+/*
+ * Copyright FalkorDB Ltd. 2023 - present
+ */
+
+/**
+ * Degree centrality (experimental).
+ *
+ * Notes:
+ * - Builds an in-memory undirected adjacency for the provided node set using `graph.traverse`.
+ * - Treats the observed edges as undirected (symmetrized), similar to exp.louvain/exp.leiden.
+ */
+
+// Ensure shared helpers are loaded when running under Node/Jest.
+// QuickJS/FalkorDB will ignore this because 'module' is not defined.
+// istanbul ignore next
+if (typeof module !== 'undefined' && module.exports) {
+  require('./community');
+}
+
+(function initExpDegreeCentrality() {
+  const g =
+    // istanbul ignore next
+    typeof globalThis !== 'undefined'
+      ? globalThis
+      : // istanbul ignore next
+        typeof self !== 'undefined'
+        ? self
+        : this;
+
+  if (!g.__flexExpAlgo) {
+    g.__flexExpAlgo = Object.create(null);
+  }
+
+  const exp = g.__flexExpAlgo;
+
+  function degreeCentrality({
+    nodes,
+    direction = 'both',
+    maxEdgesPerNode = Infinity,
+    normalized = true,
+    getNodeId = exp.defaultGetNodeId,
+    getWeight = (edge) => exp.getEdgeWeight(edge),
+    debug = false,
+  }) {
+    if (typeof exp.buildUndirectedAdjacency !== 'function') {
+      throw new TypeError('exp.degreeCentrality: missing shared helper buildUndirectedAdjacency');
+    }
+
+    const built = exp.buildUndirectedAdjacency({
+      nodes,
+      direction,
+      maxEdgesPerNode,
+      getNodeId,
+      getWeight,
+      debug,
+    });
+
+    const adjacency = built.adjacency;
+    const nodeIds = built.nodeIds;
+    const n = nodeIds.length;
+
+    const degreeById = Object.create(null);
+    const weightedDegreeById = Object.create(null);
+    const normalizedById = Object.create(null);
+
+    let maxDegree = 0;
+
+    for (const id of nodeIds) {
+      const neigh = adjacency.get(id) || new Map();
+      let deg = 0;
+      let wdeg = 0;
+
+      for (const [nbrId, w] of neigh.entries()) {
+        if (nbrId === id) continue; // ignore self-loops for centrality
+        deg += 1;
+        wdeg += w;
+      }
+
+      degreeById[String(id)] = deg;
+      weightedDegreeById[String(id)] = wdeg;
+
+      if (deg > maxDegree) maxDegree = deg;
+
+      if (normalized) {
+        normalizedById[String(id)] = n > 1 ? deg / (n - 1) : 0;
+      }
+    }
+
+    const out = {
+      n,
+      maxDegree,
+      degree: degreeById,
+      weightedDegree: weightedDegreeById,
+    };
+
+    if (normalized) {
+      out.normalized = normalizedById;
+    }
+
+    if (debug) {
+      out.debug = built.debug;
+    }
+
+    return out;
+  }
+
+  falkor.register('exp.degreeCentrality', degreeCentrality);
+
+  // Conditional Export for Jest
+  // QuickJS/FalkorDB will ignore this because 'module' is not defined.
+  // istanbul ignore next
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = {
+      degreeCentrality,
+    };
+  }
+})();

--- a/tests/exp-algo/degreeCentrality.test.js
+++ b/tests/exp-algo/degreeCentrality.test.js
@@ -1,0 +1,135 @@
+/*
+ * Copyright FalkorDB Ltd. 2023 - present
+ */
+
+const { initializeFLEX } = require('../setup');
+const degreeModule = require('../../src/exp-algo/degreeCentrality');
+
+describe('FLEX exp-algo Degree Centrality Integration Tests', () => {
+  let db, graph;
+
+  beforeAll(async () => {
+    const env = await initializeFLEX('exp_algo_degree_centrality');
+    db = env.db;
+    graph = env.graph;
+  });
+
+  afterAll(async () => {
+    if (db) {
+      await db.close();
+    }
+  });
+
+  test('module is importable in Node (conditional export)', () => {
+    expect(typeof degreeModule.degreeCentrality).toBe('function');
+  });
+
+  test('flex.exp.degreeCentrality computes degree/normalized degree on a small graph', async () => {
+    await graph.query(`MATCH (n) DETACH DELETE n`);
+
+    // Graph (directed edges, but algorithm treats as undirected):
+    // a -- b
+    // a -- c
+    // b -- c
+    // c -- d
+    // Degrees: a=2, b=2, c=3, d=1
+    await graph.query(`
+      CREATE (a:N {name:'a'}), (b:N {name:'b'}), (c:N {name:'c'}), (d:N {name:'d'})
+      CREATE
+        (a)-[:R]->(b),
+        (a)-[:R]->(c),
+        (b)-[:R]->(c),
+        (c)-[:R]->(d)
+    `);
+
+    const idRows = await graph.query(`
+      MATCH (n:N)
+      RETURN ID(n) AS id, n.name AS name
+      ORDER BY id
+    `);
+
+    const idToName = new Map();
+    for (const row of idRows.data) {
+      idToName.set(String(row.id), row.name);
+    }
+
+    const out = await graph.query(`
+      MATCH (n:N)
+      WITH n ORDER BY ID(n)
+      WITH collect(n) AS nodes
+      RETURN flex.exp.degreeCentrality({nodes: nodes}) AS res
+    `);
+
+    const res = out.data[0].res;
+    expect(res).toHaveProperty('degree');
+    expect(res).toHaveProperty('normalized');
+    expect(res.n).toBe(4);
+
+    const degByName = Object.create(null);
+    const normByName = Object.create(null);
+
+    for (const [id, deg] of Object.entries(res.degree)) {
+      const name = idToName.get(String(id));
+      degByName[name] = deg;
+    }
+
+    for (const [id, v] of Object.entries(res.normalized)) {
+      const name = idToName.get(String(id));
+      normByName[name] = v;
+    }
+
+    expect(degByName).toEqual({ a: 2, b: 2, c: 3, d: 1 });
+
+    // normalized = degree / (n-1) = degree / 3
+    expect(normByName.a).toBeCloseTo(2 / 3, 8);
+    expect(normByName.b).toBeCloseTo(2 / 3, 8);
+    expect(normByName.c).toBeCloseTo(1, 8);
+    expect(normByName.d).toBeCloseTo(1 / 3, 8);
+  });
+
+  test('weightedDegree uses relationship weight when present', async () => {
+    await graph.query(`MATCH (n) DETACH DELETE n`);
+
+    // a -- b (w=2)
+    // a -- c (w=5)
+    // weightedDegree(a) = 7
+    await graph.query(`
+      CREATE (a:N {name:'a'}), (b:N {name:'b'}), (c:N {name:'c'})
+      CREATE
+        (a)-[:R {weight:2}]->(b),
+        (a)-[:R {weight:5}]->(c)
+    `);
+
+    const idRows = await graph.query(`
+      MATCH (n:N)
+      RETURN ID(n) AS id, n.name AS name
+      ORDER BY id
+    `);
+
+    const idToName = new Map();
+    for (const row of idRows.data) {
+      idToName.set(String(row.id), row.name);
+    }
+
+    const out = await graph.query(`
+      MATCH (n:N)
+      WITH n ORDER BY ID(n)
+      WITH collect(n) AS nodes
+      RETURN flex.exp.degreeCentrality({nodes: nodes, normalized: false}) AS res
+    `);
+
+    const res = out.data[0].res;
+    expect(res).toHaveProperty('weightedDegree');
+    expect(res).not.toHaveProperty('normalized');
+
+    const wdegByName = Object.create(null);
+    for (const [id, wdeg] of Object.entries(res.weightedDegree)) {
+      const name = idToName.get(String(id));
+      wdegByName[name] = wdeg;
+    }
+
+    expect(wdegByName.a).toBe(7);
+    expect(wdegByName.b).toBe(2);
+    expect(wdegByName.c).toBe(5);
+  });
+});


### PR DESCRIPTION
Adds experimental `flex.exp.degreeCentrality` UDF + docs + integration tests.

Notes:
- Treats discovered edges as undirected (symmetrized), consistent with other exp-algo functions.
- Returns degree, weightedDegree, and optional normalized degree.

Co-Authored-By: Warp <agent@warp.dev>