### PR TITLE
exp-algo: add Leiden community detection

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -114,6 +114,7 @@ Low-level bitwise operations on integers.
 | Function | Description |
 |----------|-------------|
 | [exp.louvain](./exp-algo/louvain.md) | Louvain community detection (modularity optimization) |
+| [exp.leiden](./exp-algo/leiden.md) | Leiden-style community detection (Louvain + refinement) |
 
 ## Common Use Cases
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -115,6 +115,7 @@ Low-level bitwise operations on integers.
 |----------|-------------|
 | [exp.louvain](./exp-algo/louvain.md) | Louvain community detection (modularity optimization) |
 | [exp.leiden](./exp-algo/leiden.md) | Leiden-style community detection (Louvain + refinement) |
+| [exp.pagerankv](./exp-algo/pagerankv.md) | Weighted PageRank scores (vector) |
 
 ## Common Use Cases
 

--- a/docs/exp-algo/leiden.md
+++ b/docs/exp-algo/leiden.md
@@ -1,0 +1,87 @@
+# exp.leiden (Experimental)
+
+## Description
+Detect communities in a graph using a **Leiden-style** modularity-optimization algorithm.
+
+**Warning:** This function is **experimental**.
+- The API, behavior, and performance characteristics may change between releases.
+- It is intended for exploration and prototyping, not as a stable production API.
+
+This implementation runs inside FalkorDB’s UDF runtime and uses `graph.traverse` to build an in-memory adjacency representation of the supplied node set.
+
+Compared to `exp.louvain`, Leiden adds a **refinement** step. In this implementation, refinement is done by splitting each community into **connected components**, which helps avoid disconnected communities.
+
+## Syntax
+```cypher
+flex.exp.leiden({nodes: nodes, resolution: 1, maxLevels: 10, maxPasses: 10, seed: 42})
+```
+
+## Parameters
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `nodes` | `list<node>` | Yes | The set of nodes to cluster. Typically provided via `collect(n)`. |
+| `direction` | `string \| list<string>` | No | Which traversal direction(s) to use when building adjacency. Supported values are implementation-defined by FalkorDB UDFs; commonly `'incoming'`, `'outgoing'`, or `'both'`. Default: `'both'`. |
+| `maxEdgesPerNode` | `integer` | No | Safety cap on how many edges to scan per node when building adjacency. Default: `Infinity`. |
+| `resolution` | `float` | No | Modularity resolution parameter (γ). Higher values tend to produce smaller communities. Default: `1`. |
+| `maxPasses` | `integer` | No | Maximum number of node-moving passes per level. Default: `10`. |
+| `maxLevels` | `integer` | No | Maximum number of coarsening (aggregation) levels. Default: `10`. |
+| `minGain` | `float` | No | Minimum modularity gain required to move a node to a different community. Default: `1e-12`. |
+| `seed` | `integer` | No | When provided, uses a deterministic pseudo-random node iteration order (helps avoid order-bias and makes results reproducible). |
+| `debug` | `boolean` | No | When `true`, returns additional debug information. Default: `false`. |
+
+## Returns
+**Type:** `map`
+
+A map with the following keys:
+- `partition` (`map`): mapping from `nodeId -> communityId`.
+- `communities` (`map`): mapping from `communityId -> list<nodeId>`.
+- `levels` (`integer`): number of coarsening levels performed.
+- `debug` (`map`, optional): only present when `debug: true`.
+
+## Examples
+
+### Example 1: Team communication communities
+```cypher
+// Create a toy org with 3 teams
+CREATE
+  (alice:Person {name:'alice'}), (bob:Person {name:'bob'}), (carol:Person {name:'carol'}), (dave:Person {name:'dave'}),
+  (erin:Person {name:'erin'}), (frank:Person {name:'frank'}), (grace:Person {name:'grace'}), (heidi:Person {name:'heidi'}),
+  (ivan:Person {name:'ivan'}), (judy:Person {name:'judy'}), (mallory:Person {name:'mallory'}), (oscar:Person {name:'oscar'})
+
+CREATE
+  // Team 1 (strong)
+  (alice)-[:COMM {weight:10}]->(bob),
+  (bob)-[:COMM {weight:10}]->(carol),
+  (carol)-[:COMM {weight:10}]->(dave),
+  (dave)-[:COMM {weight:10}]->(alice),
+
+  // Team 2 (strong)
+  (erin)-[:COMM {weight:10}]->(frank),
+  (frank)-[:COMM {weight:10}]->(grace),
+  (grace)-[:COMM {weight:10}]->(heidi),
+  (heidi)-[:COMM {weight:10}]->(erin),
+
+  // Team 3 (strong)
+  (ivan)-[:COMM {weight:10}]->(judy),
+  (judy)-[:COMM {weight:10}]->(mallory),
+  (mallory)-[:COMM {weight:10}]->(oscar),
+  (oscar)-[:COMM {weight:10}]->(ivan),
+
+  // Weak cross-team comms
+  (dave)-[:COMM {weight:1}]->(erin),
+  (heidi)-[:COMM {weight:1}]->(ivan);
+
+MATCH (p:Person)
+WITH p ORDER BY ID(p)
+WITH collect(p) AS nodes
+RETURN flex.exp.leiden({nodes: nodes, seed: 42}) AS res;
+```
+
+## Notes
+- **Refinement step:** this implementation splits each community into connected components.
+- **Performance:** requires building an in-memory adjacency structure; prefer running it on a bounded subgraph.
+- **Edge weights:** uses relationship property `weight` when present; otherwise defaults to `1`.
+
+## See Also
+- [exp.louvain](./louvain.md)
+- [docs/README.md](../README.md)

--- a/docs/exp-algo/pagerankv.md
+++ b/docs/exp-algo/pagerankv.md
@@ -1,0 +1,72 @@
+# exp.pagerankv (Experimental)
+
+## Description
+Compute **PageRank** scores over a supplied set of nodes.
+
+**Warning:** This function is **experimental**.
+- The API, behavior, and performance characteristics may change between releases.
+- It is intended for exploration and prototyping, not as a stable production API.
+
+This implementation runs inside FalkorDB’s UDF runtime and uses `graph.traverse` to build an in-memory **directed** adjacency representation of the supplied node set.
+
+It supports **weighted transitions**: if an edge has a numeric weight attribute (default: `weight`), rank is distributed proportionally to that weight.
+
+## Syntax
+```cypher
+flex.exp.pagerankv({nodes: nodes, direction: 'both', damping: 0.85, maxIterations: 50, tolerance: 1e-8})
+```
+
+## Parameters
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `nodes` | `list<node>` | Yes | The node set to score. Typically provided via `collect(n)`. |
+| `direction` | `string \| list<string>` | No | Traversal direction(s) used to build adjacency. Default: `'both'`. |
+| `maxEdgesPerNode` | `integer` | No | Safety cap on how many edges to scan per node when building adjacency. Default: `Infinity`. |
+| `damping` | `float` | No | Damping factor (α). Default: `0.85`. |
+| `maxIterations` | `integer` | No | Maximum number of power-iterations. Default: `50`. |
+| `tolerance` | `float` | No | Convergence threshold (L1 delta). Default: `1e-8`. |
+| `weightAttribute` | `string \| list<string>` | No | Relationship property name(s) to read weights from. Default: `'weight'`. |
+| `defaultWeight` | `float` | No | Weight to use when no attribute is present. Default: `1`. |
+| `minWeight` | `float` | No | Clamp lower bound for weights. Default: `0`. |
+| `debug` | `boolean` | No | When `true`, returns extra debug information (adjacency stats + per-iteration deltas). Default: `false`. |
+
+## Returns
+**Type:** `map`
+
+A map with the following keys:
+- `scores` (`map`): mapping from `nodeId -> score`.
+- `iterations` (`integer`): number of iterations performed.
+- `converged` (`boolean`): whether the algorithm met the `tolerance` threshold before hitting `maxIterations`.
+- `debug` (`map`, optional): only present when `debug: true`.
+
+## Examples
+
+### Example 1: Weighted links
+```cypher
+CREATE (a:N {name:'a'}), (b:N {name:'b'}), (c:N {name:'c'})
+CREATE
+  (a)-[:R {weight: 10}]->(b),
+  (a)-[:R {weight: 1}]->(c),
+  (b)-[:R {weight: 1}]->(a),
+  (c)-[:R {weight: 1}]->(a);
+
+MATCH (n:N)
+WITH n ORDER BY ID(n)
+WITH collect(n) AS nodes
+RETURN flex.exp.pagerankv({nodes: nodes}) AS res;
+```
+
+### Example 2: Custom weight attribute
+```cypher
+MATCH (n)
+WITH n ORDER BY ID(n)
+WITH collect(n) AS nodes
+RETURN flex.exp.pagerankv({nodes: nodes, weightAttribute: 'strength'}) AS res;
+```
+
+## Notes
+- **Edge weights:** when `weightAttribute` is present and numeric, it is used to distribute rank proportionally across outgoing edges.
+- **Dangling nodes:** nodes with no outgoing edges distribute their rank uniformly to all nodes.
+
+## See Also
+- [docs/README.md](../README.md)

--- a/docs/exp-algo/pagerankv.md
+++ b/docs/exp-algo/pagerankv.md
@@ -13,7 +13,7 @@ It supports **weighted transitions**: if an edge has a numeric weight attribute 
 
 ## Syntax
 ```cypher
-flex.exp.pagerankv({nodes: nodes, direction: 'both', damping: 0.85, maxIterations: 50, tolerance: 1e-8})
+flex.exp.pagerankv({nodes: nodes, direction: 'both', damping: 0.85, maxIterations: 50, tolerance: 1e-8, personalization: {'42': 1}})
 ```
 
 ## Parameters
@@ -28,6 +28,8 @@ flex.exp.pagerankv({nodes: nodes, direction: 'both', damping: 0.85, maxIteration
 | `weightAttribute` | `string \| list<string>` | No | Relationship property name(s) to read weights from. Default: `'weight'`. |
 | `defaultWeight` | `float` | No | Weight to use when no attribute is present. Default: `1`. |
 | `minWeight` | `float` | No | Clamp lower bound for weights. Default: `0`. |
+| `personalization` | `map<string, float>` | No | Personalized restart weights keyed by node id. Keys may be a subset of supplied nodes. Values are normalized over in-graph keys. Missing nodes receive zero. Default: uniform distribution over all nodes. |
+| `dangling` | `map<string, float>` | No | Redistribution weights for dangling nodes (nodes with no outgoing edges). Values are normalized over in-graph keys. Default: `personalization` (or uniform when `personalization` is omitted). |
 | `debug` | `boolean` | No | When `true`, returns extra debug information (adjacency stats + per-iteration deltas). Default: `false`. |
 
 ## Returns
@@ -64,9 +66,25 @@ WITH collect(n) AS nodes
 RETURN flex.exp.pagerankv({nodes: nodes, weightAttribute: 'strength'}) AS res;
 ```
 
+### Example 3: Personalized PageRank (seed-biased restarts)
+```cypher
+MATCH (n:N)
+WITH n ORDER BY ID(n)
+WITH collect(n) AS nodes
+RETURN flex.exp.pagerankv({
+  nodes: nodes,
+  personalization: {
+    '42': 0.7,
+    '87': 0.3
+  }
+}) AS res;
+```
+
 ## Notes
 - **Edge weights:** when `weightAttribute` is present and numeric, it is used to distribute rank proportionally across outgoing edges.
-- **Dangling nodes:** nodes with no outgoing edges distribute their rank uniformly to all nodes.
+- **Personalization normalization:** `personalization` does not need to sum to `1`; in-graph values are normalized automatically.
+- **Dangling nodes:** when `dangling` is omitted, dangling mass is redistributed using the personalization distribution (uniform when no personalization is provided).
+- **Validation:** `personalization` and `dangling` values must be finite and non-negative, and at least one in-graph value must be positive.
 
 ## See Also
 - [docs/README.md](../README.md)

--- a/src/exp-algo/leiden.js
+++ b/src/exp-algo/leiden.js
@@ -1,0 +1,261 @@
+/*
+ * Copyright FalkorDB Ltd. 2023 - present
+ */
+
+/**
+ * Leiden community detection (experimental).
+ *
+ * Pragmatic UDF-oriented variant:
+ * - Local moving (Louvain-style)
+ * - Refinement by splitting communities into connected components
+ * - Graph coarsening (induced graph)
+ */
+
+// Ensure shared helpers are loaded when running under Node/Jest.
+// QuickJS/FalkorDB will ignore this because 'module' is not defined.
+// istanbul ignore next
+if (typeof module !== 'undefined' && module.exports) {
+  require('./community');
+}
+
+(function initExpLeiden() {
+  const g =
+    // istanbul ignore next
+    typeof globalThis !== 'undefined'
+      ? globalThis
+      : // istanbul ignore next
+        typeof self !== 'undefined'
+        ? self
+        : this;
+
+  if (!g.__flexExpAlgo) {
+    g.__flexExpAlgo = Object.create(null);
+  }
+
+  const exp = g.__flexExpAlgo;
+
+  function makeSeededRandom(seed) {
+    // Simple LCG (deterministic).
+    let s = (seed >>> 0) || 1;
+    return function random() {
+      s = (1664525 * s + 1013904223) >>> 0;
+      return s / 4294967296;
+    };
+  }
+
+  /**
+   * Refinement step: split each community into connected components
+   * (with connectivity computed inside the community induced subgraph).
+   */
+  function refineByConnectedComponents({ adjacency, nodeIds, partition }) {
+    const communities = exp.partitionToCommunities(partition);
+
+    const refined = new Map();
+    let splitCommunities = 0;
+    let totalComponents = 0;
+
+    for (const [comm, nodes] of communities.entries()) {
+      if (!nodes || nodes.length <= 1) {
+        if (nodes && nodes.length === 1) refined.set(nodes[0], comm);
+        continue;
+      }
+
+      const inComm = new Set(nodes);
+      const visited = new Set();
+
+      let componentsForThisCommunity = 0;
+
+      for (const start of nodes) {
+        if (visited.has(start)) continue;
+
+        componentsForThisCommunity += 1;
+        totalComponents += 1;
+
+        const compKey = `${String(comm)}__${componentsForThisCommunity}`;
+
+        // BFS
+        const q = [start];
+        visited.add(start);
+        refined.set(start, compKey);
+
+        while (q.length) {
+          const v = q.pop();
+          const neigh = adjacency.get(v);
+          if (!neigh) continue;
+
+          for (const nbr of neigh.keys()) {
+            if (!inComm.has(nbr)) continue;
+            if (visited.has(nbr)) continue;
+            visited.add(nbr);
+            refined.set(nbr, compKey);
+            q.push(nbr);
+          }
+        }
+      }
+
+      if (componentsForThisCommunity > 1) {
+        splitCommunities += 1;
+      }
+
+      // If the community was actually connected, keep the original id to reduce churn.
+      if (componentsForThisCommunity === 1) {
+        for (const n of nodes) {
+          refined.set(n, comm);
+        }
+      }
+    }
+
+    // Ensure every nodeId is present (defensive).
+    for (const id of nodeIds) {
+      if (!refined.has(id)) {
+        refined.set(id, partition.get(id));
+      }
+    }
+
+    return {
+      partition: exp.renumberPartition(refined),
+      splitCommunities,
+      totalComponents,
+    };
+  }
+
+  /**
+   * Leiden algorithm.
+   *
+   * @param {object} params
+   * @param {any[]} params.nodes Input nodes (objects), must include `id` by default.
+   * @param {string|string[]} [params.direction='both'] Traversal direction(s) used to build adjacency.
+   * @param {number} [params.maxEdgesPerNode=Infinity] Safety cap per node traversal.
+   * @param {number} [params.resolution=1] Modularity resolution (gamma).
+   * @param {number} [params.maxPasses=10] Max passes per level.
+   * @param {number} [params.maxLevels=10] Max coarsening levels.
+   * @param {number} [params.minGain=1e-12] Minimum gain threshold to accept a move.
+   * @param {number} [params.seed] Deterministic seed for randomized node order.
+   * @param {(node:any)=>any} [params.getNodeId]
+   * @param {(edge:any)=>number} [params.getWeight]
+   * @param {boolean} [params.debug=false]
+   */
+  function leiden({
+    nodes,
+    direction = 'both',
+    maxEdgesPerNode = Infinity,
+    resolution = 1,
+    maxPasses = 10,
+    maxLevels = 10,
+    minGain = 1e-12,
+    seed,
+    getNodeId = exp.defaultGetNodeId,
+    getWeight = (edge) => exp.getEdgeWeight(edge),
+    debug = false,
+  }) {
+    const built = exp.buildUndirectedAdjacency({
+      nodes,
+      direction,
+      maxEdgesPerNode,
+      getNodeId,
+      getWeight,
+      debug,
+    });
+
+    const baseAdj = built.adjacency;
+    const baseNodeIds = built.nodeIds;
+
+    const random = Number.isFinite(seed) ? makeSeededRandom(seed) : undefined;
+
+    // Mapping from original nodeId -> current node id in the coarsened graph.
+    const originalToCurrent = new Map();
+    for (const id of baseNodeIds) originalToCurrent.set(id, id);
+
+    let currentAdj = baseAdj;
+    let currentNodeIds = baseNodeIds;
+    let levels = 0;
+
+    const debugOut = debug
+      ? {
+          adjacency: built.debug,
+          levels: [],
+        }
+      : null;
+
+    for (let level = 0; level < maxLevels; level++) {
+      const movedRes = exp.oneLevel({
+        adjacency: currentAdj,
+        nodeIds: currentNodeIds,
+        resolution,
+        maxPasses,
+        minGain,
+        random,
+      });
+
+      const partLocal = movedRes.partition;
+
+      const refinedRes = refineByConnectedComponents({
+        adjacency: currentAdj,
+        nodeIds: currentNodeIds,
+        partition: partLocal,
+      });
+
+      const part = refinedRes.partition;
+
+      levels += 1;
+
+      if (debugOut) {
+        debugOut.levels.push({
+          moved: movedRes.moved,
+          moves: movedRes.moves,
+          splitCommunities: refinedRes.splitCommunities,
+          totalComponents: refinedRes.totalComponents,
+          communities: exp.partitionToCommunities(part).size,
+        });
+      }
+
+      // Update original mapping: original -> part(current).
+      for (const [orig, cur] of originalToCurrent.entries()) {
+        originalToCurrent.set(orig, part.get(cur));
+      }
+
+      // If nothing moved and nothing split, stop.
+      if (!movedRes.moved && refinedRes.splitCommunities === 0) {
+        break;
+      }
+
+      const induced = exp.inducedGraph({ adjacency: currentAdj, partition: part });
+
+      // If coarsening doesn't reduce the graph, stop.
+      if (induced.nodeIds.length >= currentNodeIds.length) {
+        break;
+      }
+
+      currentAdj = induced.adjacency;
+      currentNodeIds = induced.nodeIds;
+    }
+
+    // Renumber final communities densely.
+    const finalPartition = exp.renumberPartition(originalToCurrent);
+    const communities = exp.partitionToCommunities(finalPartition);
+
+    const out = {
+      partition: exp.partitionToObject(finalPartition),
+      communities: exp.communitiesToObject(communities),
+      levels,
+    };
+
+    if (debug) {
+      out.debug = debugOut;
+    }
+
+    return out;
+  }
+
+  falkor.register('exp.leiden', leiden);
+
+  // Conditional Export for Jest
+  // QuickJS/FalkorDB will ignore this because 'module' is not defined.
+  // istanbul ignore next
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = {
+      refineByConnectedComponents,
+      leiden,
+    };
+  }
+})();

--- a/src/exp-algo/pagerankv.js
+++ b/src/exp-algo/pagerankv.js
@@ -1,0 +1,233 @@
+/*
+ * Copyright FalkorDB Ltd. 2023 - present
+ */
+
+/**
+ * PageRank (experimental) with optional edge weight consideration.
+ *
+ * Pragmatic UDF-oriented implementation:
+ * - builds directed adjacency from a provided node set using graph.traverse
+ * - runs power-iteration until convergence or maxIterations
+ * - supports weighted transitions based on an edge weight attribute
+ */
+
+// Ensure shared helpers are loaded when running under Node/Jest.
+// QuickJS/FalkorDB will ignore this because 'module' is not defined.
+// istanbul ignore next
+if (typeof module !== 'undefined' && module.exports) {
+  require('./community');
+}
+
+(function initExpPageRankV() {
+  const g =
+    // istanbul ignore next
+    typeof globalThis !== 'undefined'
+      ? globalThis
+      : // istanbul ignore next
+        typeof self !== 'undefined'
+        ? self
+        : this;
+
+  if (!g.__flexExpAlgo) {
+    g.__flexExpAlgo = Object.create(null);
+  }
+
+  const exp = g.__flexExpAlgo;
+
+  function mapToObject(map) {
+    const obj = Object.create(null);
+    for (const [k, v] of map.entries()) {
+      obj[String(k)] = v;
+    }
+    return obj;
+  }
+
+  /**
+   * Weighted PageRank over a node set.
+   *
+   * @param {object} params
+   * @param {any[]} params.nodes Input nodes (objects), must include `id` by default.
+   * @param {string|string[]} [params.direction='both'] Traversal direction(s) used to build adjacency.
+   * @param {number} [params.maxEdgesPerNode=Infinity] Safety cap per node traversal.
+   * @param {number} [params.damping=0.85] Damping factor (alpha).
+   * @param {number} [params.maxIterations=50] Maximum power-iterations.
+   * @param {number} [params.tolerance=1e-8] L1 delta threshold for convergence.
+   * @param {string|string[]} [params.weightAttribute='weight'] Edge attribute(s) to read weight from.
+   * @param {number} [params.defaultWeight=1] Weight to use when attribute is missing.
+   * @param {number} [params.minWeight=0] Lower bound clamp for weights.
+   * @param {(node:any)=>any} [params.getNodeId]
+   * @param {boolean} [params.debug=false]
+   *
+   * @returns {{ scores: Object, iterations: number, converged: boolean, debug?: Object }}
+   */
+  function pagerankv({
+    nodes,
+    direction = 'both',
+    maxEdgesPerNode = Infinity,
+    damping = 0.85,
+    maxIterations = 50,
+    tolerance = 1e-8,
+    weightAttribute = 'weight',
+    defaultWeight = 1,
+    minWeight = 0,
+    getNodeId = exp.defaultGetNodeId,
+    debug = false,
+  }) {
+    const keys = Array.isArray(weightAttribute) ? weightAttribute : [weightAttribute];
+
+    const getWeight = (edge) =>
+      exp.getEdgeWeight(edge, {
+        keys,
+        defaultValue: defaultWeight,
+        minValue: minWeight,
+      });
+
+    const built = exp.buildDirectedAdjacency({
+      nodes,
+      direction,
+      maxEdgesPerNode,
+      getNodeId,
+      getWeight,
+      debug,
+    });
+
+    const nodeIds = built.nodeIds;
+    const adjacency = built.adjacency;
+    const n = nodeIds.length;
+
+    if (n === 0) {
+      return { scores: Object.create(null), iterations: 0, converged: true };
+    }
+
+    const clampDamping =
+      typeof damping === 'number' && Number.isFinite(damping)
+        ? Math.min(1, Math.max(0, damping))
+        : 0.85;
+
+    const maxIter =
+      typeof maxIterations === 'number' && Number.isFinite(maxIterations) && maxIterations > 0
+        ? Math.floor(maxIterations)
+        : 50;
+
+    const tol =
+      typeof tolerance === 'number' && Number.isFinite(tolerance) && tolerance >= 0
+        ? tolerance
+        : 1e-8;
+
+    const index = new Map();
+    for (let i = 0; i < n; i++) {
+      index.set(nodeIds[i], i);
+    }
+
+    const outWeight = new Array(n);
+    for (let i = 0; i < n; i++) {
+      const id = nodeIds[i];
+      const row = adjacency.get(id);
+      let s = 0;
+      if (row) {
+        for (const w of row.values()) {
+          if (w > 0) s += w;
+        }
+      }
+      outWeight[i] = s;
+    }
+
+    // Initial uniform distribution.
+    let rank = new Array(n);
+    for (let i = 0; i < n; i++) rank[i] = 1 / n;
+
+    let next = new Array(n);
+
+    const base = (1 - clampDamping) / n;
+
+    let converged = false;
+    let iterations = 0;
+    const deltas = debug ? [] : null;
+
+    for (let iter = 0; iter < maxIter; iter++) {
+      iterations = iter + 1;
+
+      for (let i = 0; i < n; i++) next[i] = base;
+
+      let danglingMass = 0;
+
+      for (let i = 0; i < n; i++) {
+        const r = rank[i];
+        const ow = outWeight[i];
+        if (!(ow > 0)) {
+          danglingMass += r;
+          continue;
+        }
+
+        const srcId = nodeIds[i];
+        const row = adjacency.get(srcId);
+        if (!row) {
+          danglingMass += r;
+          continue;
+        }
+
+        const factor = (clampDamping * r) / ow;
+
+        for (const [dstId, w] of row.entries()) {
+          if (!(w > 0)) continue;
+          const j = index.get(dstId);
+          if (typeof j !== 'number') continue;
+          next[j] += factor * w;
+        }
+      }
+
+      if (danglingMass > 0) {
+        const add = (clampDamping * danglingMass) / n;
+        for (let j = 0; j < n; j++) next[j] += add;
+      }
+
+      let delta = 0;
+      for (let j = 0; j < n; j++) {
+        delta += Math.abs(next[j] - rank[j]);
+      }
+
+      if (deltas) deltas.push(delta);
+
+      // swap
+      const tmp = rank;
+      rank = next;
+      next = tmp;
+
+      if (delta <= tol) {
+        converged = true;
+        break;
+      }
+    }
+
+    const scores = new Map();
+    for (let i = 0; i < n; i++) {
+      scores.set(nodeIds[i], rank[i]);
+    }
+
+    const out = {
+      scores: mapToObject(scores),
+      iterations,
+      converged,
+    };
+
+    if (debug) {
+      out.debug = {
+        adjacency: built.debug,
+        deltas,
+      };
+    }
+
+    return out;
+  }
+
+  falkor.register('exp.pagerankv', pagerankv);
+
+  // Conditional Export for Jest
+  // QuickJS/FalkorDB will ignore this because 'module' is not defined.
+  // istanbul ignore next
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = {
+      pagerankv,
+    };
+  }
+})();

--- a/src/exp-algo/pagerankv.js
+++ b/src/exp-algo/pagerankv.js
@@ -42,6 +42,54 @@ if (typeof module !== 'undefined' && module.exports) {
     return obj;
   }
 
+  function normalizeNodeWeightMap(raw, { n, stableIndex, name }) {
+    if (raw == null) {
+      const uniform = new Array(n);
+      for (let i = 0; i < n; i++) uniform[i] = 1 / n;
+      return uniform;
+    }
+
+    const isMap = raw instanceof Map;
+    const isObject = !isMap && typeof raw === 'object' && !Array.isArray(raw);
+    if (!isObject && !isMap) {
+      throw new TypeError(`pagerankv: \`${name}\` must be an object map or Map`);
+    }
+
+    const vec = new Array(n);
+    for (let i = 0; i < n; i++) vec[i] = 0;
+
+    const addEntry = (k, v) => {
+      if (typeof v !== 'number' || !Number.isFinite(v)) {
+        throw new TypeError(`pagerankv: \`${name}\` values must be finite numbers`);
+      }
+      if (v < 0) {
+        throw new RangeError(`pagerankv: \`${name}\` values must be >= 0`);
+      }
+
+      const sid = exp.stableKeyPart(k);
+      const idx = stableIndex.get(sid);
+      if (typeof idx !== 'number') return;
+      vec[idx] += v;
+    };
+
+    if (isMap) {
+      for (const [k, v] of raw.entries()) addEntry(k, v);
+    } else {
+      for (const [k, v] of Object.entries(raw)) addEntry(k, v);
+    }
+
+    let sum = 0;
+    for (let i = 0; i < n; i++) sum += vec[i];
+    if (!(sum > 0)) {
+      throw new TypeError(
+        `pagerankv: \`${name}\` must assign positive weight to at least one input node`
+      );
+    }
+
+    for (let i = 0; i < n; i++) vec[i] /= sum;
+    return vec;
+  }
+
   /**
    * Weighted PageRank over a node set.
    *
@@ -55,6 +103,8 @@ if (typeof module !== 'undefined' && module.exports) {
    * @param {string|string[]} [params.weightAttribute='weight'] Edge attribute(s) to read weight from.
    * @param {number} [params.defaultWeight=1] Weight to use when attribute is missing.
    * @param {number} [params.minWeight=0] Lower bound clamp for weights.
+   * @param {Object<string,number>|Map<any,number>} [params.personalization]
+   * @param {Object<string,number>|Map<any,number>} [params.dangling]
    * @param {(node:any)=>any} [params.getNodeId]
    * @param {boolean} [params.debug=false]
    *
@@ -70,6 +120,8 @@ if (typeof module !== 'undefined' && module.exports) {
     weightAttribute = 'weight',
     defaultWeight = 1,
     minWeight = 0,
+    personalization = null,
+    dangling = null,
     getNodeId = exp.defaultGetNodeId,
     debug = false,
   }) {
@@ -115,8 +167,11 @@ if (typeof module !== 'undefined' && module.exports) {
         : 1e-8;
 
     const index = new Map();
+    const stableIndex = new Map();
     for (let i = 0; i < n; i++) {
-      index.set(nodeIds[i], i);
+      const id = nodeIds[i];
+      index.set(id, i);
+      stableIndex.set(exp.stableKeyPart(id), i);
     }
 
     const outWeight = new Array(n);
@@ -138,7 +193,20 @@ if (typeof module !== 'undefined' && module.exports) {
 
     let next = new Array(n);
 
-    const base = (1 - clampDamping) / n;
+    const personalizationVector = normalizeNodeWeightMap(personalization, {
+      n,
+      stableIndex,
+      name: 'personalization',
+    });
+
+    const danglingVector =
+      dangling == null
+        ? personalizationVector
+        : normalizeNodeWeightMap(dangling, {
+            n,
+            stableIndex,
+            name: 'dangling',
+          });
 
     let converged = false;
     let iterations = 0;
@@ -147,7 +215,7 @@ if (typeof module !== 'undefined' && module.exports) {
     for (let iter = 0; iter < maxIter; iter++) {
       iterations = iter + 1;
 
-      for (let i = 0; i < n; i++) next[i] = base;
+      for (let i = 0; i < n; i++) next[i] = (1 - clampDamping) * personalizationVector[i];
 
       let danglingMass = 0;
 
@@ -177,8 +245,8 @@ if (typeof module !== 'undefined' && module.exports) {
       }
 
       if (danglingMass > 0) {
-        const add = (clampDamping * danglingMass) / n;
-        for (let j = 0; j < n; j++) next[j] += add;
+        const add = clampDamping * danglingMass;
+        for (let j = 0; j < n; j++) next[j] += add * danglingVector[j];
       }
 
       let delta = 0;

--- a/tests/exp-algo/leiden.test.js
+++ b/tests/exp-algo/leiden.test.js
@@ -1,0 +1,159 @@
+/*
+ * Copyright FalkorDB Ltd. 2023 - present
+ */
+
+const { initializeFLEX } = require('../setup');
+const leidenModule = require('../../src/exp-algo/leiden');
+
+describe('FLEX exp-algo Leiden Integration Tests', () => {
+  let db, graph;
+
+  beforeAll(async () => {
+    const env = await initializeFLEX('exp_algo_leiden');
+    db = env.db;
+    graph = env.graph;
+  });
+
+  afterAll(async () => {
+    if (db) {
+      await db.close();
+    }
+  });
+
+  test('module is importable in Node (conditional export)', () => {
+    expect(typeof leidenModule.leiden).toBe('function');
+  });
+
+  test('refinement splits a disconnected community into connected components (unit test)', () => {
+    const adjacency = new Map();
+    adjacency.set(1, new Map([[2, 1]]));
+    adjacency.set(2, new Map([[1, 1]]));
+    adjacency.set(3, new Map([[4, 1]]));
+    adjacency.set(4, new Map([[3, 1]]));
+
+    const partition = new Map([
+      [1, 'A'],
+      [2, 'A'],
+      [3, 'A'],
+      [4, 'A'],
+    ]);
+
+    const res = leidenModule.refineByConnectedComponents({
+      adjacency,
+      nodeIds: [1, 2, 3, 4],
+      partition,
+    });
+
+    expect(res.splitCommunities).toBe(1);
+    expect(res.totalComponents).toBe(2);
+
+    const p = res.partition;
+    expect(p.get(1)).toBe(p.get(2));
+    expect(p.get(3)).toBe(p.get(4));
+    expect(p.get(1)).not.toBe(p.get(3));
+  });
+
+  test('flex.exp.leiden is callable and finds communities in a more realistic weighted graph', async () => {
+    // Make the test idempotent when re-run against the same local DB.
+    await graph.query(`MATCH (n) DETACH DELETE n`);
+
+    // Same scenario as Louvain test: 3 teams with strong intra-team ties (10)
+    // and weak cross-team ties (1). Expect 3 communities of size 4.
+    await graph.query(`
+      CREATE
+        // Team 1
+        (alice:N {name:'alice'}), (bob:N {name:'bob'}), (carol:N {name:'carol'}), (dave:N {name:'dave'}),
+        // Team 2
+        (erin:N {name:'erin'}), (frank:N {name:'frank'}), (grace:N {name:'grace'}), (heidi:N {name:'heidi'}),
+        // Team 3
+        (ivan:N {name:'ivan'}), (judy:N {name:'judy'}), (mallory:N {name:'mallory'}), (oscar:N {name:'oscar'})
+
+      CREATE
+        // Team 1
+        (alice)-[:R {weight:10}]->(bob),
+        (bob)-[:R {weight:10}]->(carol),
+        (carol)-[:R {weight:10}]->(dave),
+        (dave)-[:R {weight:10}]->(alice),
+        (alice)-[:R {weight:10}]->(carol),
+        (bob)-[:R {weight:10}]->(dave),
+
+        // Team 2
+        (erin)-[:R {weight:10}]->(frank),
+        (frank)-[:R {weight:10}]->(grace),
+        (grace)-[:R {weight:10}]->(heidi),
+        (heidi)-[:R {weight:10}]->(erin),
+        (erin)-[:R {weight:10}]->(grace),
+        (frank)-[:R {weight:10}]->(heidi),
+
+        // Team 3
+        (ivan)-[:R {weight:10}]->(judy),
+        (judy)-[:R {weight:10}]->(mallory),
+        (mallory)-[:R {weight:10}]->(oscar),
+        (oscar)-[:R {weight:10}]->(ivan),
+        (ivan)-[:R {weight:10}]->(mallory),
+        (judy)-[:R {weight:10}]->(oscar),
+
+        // Weak cross-team edges
+        (dave)-[:R {weight:1}]->(erin),
+        (heidi)-[:R {weight:1}]->(ivan),
+        (carol)-[:R {weight:1}]->(grace)
+    `);
+
+    // Get stable id->name mapping
+    const idRows = await graph.query(`
+      MATCH (n:N)
+      RETURN ID(n) AS id, n.name AS name
+      ORDER BY id
+    `);
+
+    const idToName = new Map();
+    for (const row of idRows.data) {
+      idToName.set(String(row.id), row.name);
+    }
+
+    const out = await graph.query(`
+      MATCH (n:N)
+      WITH n ORDER BY ID(n)
+      WITH collect(n) AS nodes
+      RETURN flex.exp.leiden({nodes: nodes, seed: 42}) AS res
+    `);
+
+    const res = out.data[0].res;
+
+    expect(res).toHaveProperty('partition');
+    expect(res).toHaveProperty('communities');
+
+    const communities = res.communities;
+    const commKeys = Object.keys(communities);
+
+    expect(commKeys.length).toBe(3);
+
+    const nameSets = commKeys.map((k) => {
+      const ids = communities[k] || [];
+      const names = ids.map((id) => idToName.get(String(id)));
+      return new Set(names);
+    });
+
+    for (const s of nameSets) {
+      expect(s.size).toBe(4);
+    }
+
+    const team1 = new Set(['alice', 'bob', 'carol', 'dave']);
+    const team2 = new Set(['erin', 'frank', 'grace', 'heidi']);
+    const team3 = new Set(['ivan', 'judy', 'mallory', 'oscar']);
+
+    function sameSet(a, b) {
+      if (a.size !== b.size) return false;
+      for (const v of a) if (!b.has(v)) return false;
+      return true;
+    }
+
+    const hasTeam1 = nameSets.some((s) => sameSet(s, team1));
+    const hasTeam2 = nameSets.some((s) => sameSet(s, team2));
+    const hasTeam3 = nameSets.some((s) => sameSet(s, team3));
+
+    expect(hasTeam1).toBe(true);
+    expect(hasTeam2).toBe(true);
+    expect(hasTeam3).toBe(true);
+  });
+});

--- a/tests/exp-algo/pagerankv.test.js
+++ b/tests/exp-algo/pagerankv.test.js
@@ -1,0 +1,81 @@
+/*
+ * Copyright FalkorDB Ltd. 2023 - present
+ */
+
+const { initializeFLEX } = require('../setup');
+const pagerankvModule = require('../../src/exp-algo/pagerankv');
+
+describe('FLEX exp-algo PageRankV Integration Tests', () => {
+  let db, graph;
+
+  beforeAll(async () => {
+    const env = await initializeFLEX('exp_algo_pagerankv');
+    db = env.db;
+    graph = env.graph;
+  });
+
+  afterAll(async () => {
+    if (db) {
+      await db.close();
+    }
+  });
+
+  test('module is importable in Node (conditional export)', () => {
+    expect(typeof pagerankvModule.pagerankv).toBe('function');
+  });
+
+  test('flex.exp.pagerankv considers edge weights (heavier link gives higher score)', async () => {
+    // Make the test idempotent when re-run against the same local DB.
+    await graph.query(`MATCH (n) DETACH DELETE n`);
+
+    // Symmetric-ish graph, except A->B has much larger weight than A->C.
+    await graph.query(`
+      CREATE (a:N {name:'a'}), (b:N {name:'b'}), (c:N {name:'c'})
+      CREATE
+        (a)-[:R {weight:10}]->(b),
+        (a)-[:R {weight:1}]->(c),
+        (b)-[:R {weight:1}]->(a),
+        (c)-[:R {weight:1}]->(a)
+    `);
+
+    const idRows = await graph.query(`
+      MATCH (n:N)
+      RETURN ID(n) AS id, n.name AS name
+      ORDER BY id
+    `);
+
+    const nameToId = new Map();
+    for (const row of idRows.data) {
+      nameToId.set(row.name, String(row.id));
+    }
+
+    const out = await graph.query(`
+      MATCH (n:N)
+      WITH n ORDER BY ID(n)
+      WITH collect(n) AS nodes
+      RETURN flex.exp.pagerankv({nodes: nodes, maxIterations: 200, tolerance: 1e-12}) AS res
+    `);
+
+    const res = out.data[0].res;
+    expect(res).toHaveProperty('scores');
+    expect(res).toHaveProperty('iterations');
+    expect(res).toHaveProperty('converged');
+
+    const scores = res.scores;
+
+    const a = scores[nameToId.get('a')];
+    const b = scores[nameToId.get('b')];
+    const c = scores[nameToId.get('c')];
+
+    expect(typeof a).toBe('number');
+    expect(typeof b).toBe('number');
+    expect(typeof c).toBe('number');
+
+    // Weight should push more rank from A to B than to C.
+    expect(b).toBeGreaterThan(c);
+
+    const sum = a + b + c;
+    expect(sum).toBeGreaterThan(0.999);
+    expect(sum).toBeLessThan(1.001);
+  });
+});

--- a/tests/exp-algo/pagerankv.test.js
+++ b/tests/exp-algo/pagerankv.test.js
@@ -78,4 +78,115 @@ describe('FLEX exp-algo PageRankV Integration Tests', () => {
     expect(sum).toBeGreaterThan(0.999);
     expect(sum).toBeLessThan(1.001);
   });
+
+  test('flex.exp.pagerankv supports NetworkX-style personalization (subset keys + normalization)', async () => {
+    await graph.query(`MATCH (n) DETACH DELETE n`);
+
+    // Directed 3-cycle. Without personalization, scores would be uniform.
+    await graph.query(`
+      CREATE (a:N {name:'a'}), (b:N {name:'b'}), (c:N {name:'c'})
+      CREATE
+        (a)-[:R {weight:1}]->(b),
+        (b)-[:R {weight:1}]->(c),
+        (c)-[:R {weight:1}]->(a)
+    `);
+
+    const idRows = await graph.query(`
+      MATCH (n:N)
+      RETURN ID(n) AS id, n.name AS name
+      ORDER BY id
+    `);
+
+    const nameToId = new Map();
+    for (const row of idRows.data) {
+      nameToId.set(row.name, String(row.id));
+    }
+
+    const aId = nameToId.get('a');
+
+    const out = await graph.query(`
+      MATCH (n:N)
+      WITH n ORDER BY ID(n)
+      WITH collect(n) AS nodes
+      RETURN flex.exp.pagerankv({
+        nodes: nodes,
+        maxIterations: 300,
+        tolerance: 1e-12,
+        personalization: flex.map.fromPairs([['${aId}', 10]])
+      }) AS res
+    `);
+
+    const res = out.data[0].res;
+    const scores = res.scores;
+
+    const a = scores[nameToId.get('a')];
+    const b = scores[nameToId.get('b')];
+    const c = scores[nameToId.get('c')];
+
+    expect(a).toBeGreaterThan(b);
+    expect(b).toBeGreaterThan(c);
+
+    const sum = a + b + c;
+    expect(sum).toBeGreaterThan(0.999);
+    expect(sum).toBeLessThan(1.001);
+  });
+
+  test('flex.exp.pagerankv uses personalization for dangling redistribution by default', async () => {
+    await graph.query(`MATCH (n) DETACH DELETE n`);
+
+    // Node b is dangling (no outgoing edges).
+    await graph.query(`
+      CREATE (a:N {name:'a'}), (b:N {name:'b'})
+      CREATE (a)-[:R {weight:1}]->(b)
+    `);
+
+    const idRows = await graph.query(`
+      MATCH (n:N)
+      RETURN ID(n) AS id, n.name AS name
+      ORDER BY id
+    `);
+
+    const nameToId = new Map();
+    for (const row of idRows.data) {
+      nameToId.set(row.name, String(row.id));
+    }
+
+    const aId = nameToId.get('a');
+    const bId = nameToId.get('b');
+
+    const defaultDanglingOut = await graph.query(`
+      MATCH (n:N)
+      WITH n ORDER BY ID(n)
+      WITH collect(n) AS nodes
+      RETURN flex.exp.pagerankv({
+        nodes: nodes,
+        maxIterations: 300,
+        tolerance: 1e-12,
+        personalization: flex.map.fromPairs([['${aId}', 1]])
+      }) AS res
+    `);
+
+    const defaultScores = defaultDanglingOut.data[0].res.scores;
+    const aDefault = defaultScores[aId];
+    const bDefault = defaultScores[bId];
+    expect(aDefault).toBeGreaterThan(bDefault);
+
+    const explicitDanglingOut = await graph.query(`
+      MATCH (n:N)
+      WITH n ORDER BY ID(n)
+      WITH collect(n) AS nodes
+      RETURN flex.exp.pagerankv({
+        nodes: nodes,
+        maxIterations: 300,
+        tolerance: 1e-12,
+        personalization: flex.map.fromPairs([['${aId}', 1]]),
+        dangling: flex.map.fromPairs([['${bId}', 1]])
+      }) AS res
+    `);
+
+    const explicitScores = explicitDanglingOut.data[0].res.scores;
+    const aExplicit = explicitScores[aId];
+    const bExplicit = explicitScores[bId];
+    expect(bExplicit).toBeGreaterThan(aExplicit);
+  });
 });


### PR DESCRIPTION
Adds experimental `flex.exp.leiden` community detection UDF.

This PR is intentionally stacked on top of the Louvain+community infra PR (#70).

Co-Authored-By: Warp <agent@warp.dev>