### PR TITLE
exp: add pagerankv (weighted PageRank)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -115,6 +115,7 @@ Low-level bitwise operations on integers.
 |----------|-------------|
 | [exp.louvain](./exp-algo/louvain.md) | Louvain community detection (modularity optimization) |
 | [exp.leiden](./exp-algo/leiden.md) | Leiden-style community detection (Louvain + refinement) |
+| [exp.pagerankv](./exp-algo/pagerankv.md) | Weighted PageRank scores (vector) |
 
 ## Common Use Cases
 

--- a/docs/exp-algo/pagerankv.md
+++ b/docs/exp-algo/pagerankv.md
@@ -1,0 +1,72 @@
+# exp.pagerankv (Experimental)
+
+## Description
+Compute **PageRank** scores over a supplied set of nodes.
+
+**Warning:** This function is **experimental**.
+- The API, behavior, and performance characteristics may change between releases.
+- It is intended for exploration and prototyping, not as a stable production API.
+
+This implementation runs inside FalkorDB’s UDF runtime and uses `graph.traverse` to build an in-memory **directed** adjacency representation of the supplied node set.
+
+It supports **weighted transitions**: if an edge has a numeric weight attribute (default: `weight`), rank is distributed proportionally to that weight.
+
+## Syntax
+```cypher
+flex.exp.pagerankv({nodes: nodes, direction: 'both', damping: 0.85, maxIterations: 50, tolerance: 1e-8})
+```
+
+## Parameters
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `nodes` | `list<node>` | Yes | The node set to score. Typically provided via `collect(n)`. |
+| `direction` | `string \| list<string>` | No | Traversal direction(s) used to build adjacency. Default: `'both'`. |
+| `maxEdgesPerNode` | `integer` | No | Safety cap on how many edges to scan per node when building adjacency. Default: `Infinity`. |
+| `damping` | `float` | No | Damping factor (α). Default: `0.85`. |
+| `maxIterations` | `integer` | No | Maximum number of power-iterations. Default: `50`. |
+| `tolerance` | `float` | No | Convergence threshold (L1 delta). Default: `1e-8`. |
+| `weightAttribute` | `string \| list<string>` | No | Relationship property name(s) to read weights from. Default: `'weight'`. |
+| `defaultWeight` | `float` | No | Weight to use when no attribute is present. Default: `1`. |
+| `minWeight` | `float` | No | Clamp lower bound for weights. Default: `0`. |
+| `debug` | `boolean` | No | When `true`, returns extra debug information (adjacency stats + per-iteration deltas). Default: `false`. |
+
+## Returns
+**Type:** `map`
+
+A map with the following keys:
+- `scores` (`map`): mapping from `nodeId -> score`.
+- `iterations` (`integer`): number of iterations performed.
+- `converged` (`boolean`): whether the algorithm met the `tolerance` threshold before hitting `maxIterations`.
+- `debug` (`map`, optional): only present when `debug: true`.
+
+## Examples
+
+### Example 1: Weighted links
+```cypher
+CREATE (a:N {name:'a'}), (b:N {name:'b'}), (c:N {name:'c'})
+CREATE
+  (a)-[:R {weight: 10}]->(b),
+  (a)-[:R {weight: 1}]->(c),
+  (b)-[:R {weight: 1}]->(a),
+  (c)-[:R {weight: 1}]->(a);
+
+MATCH (n:N)
+WITH n ORDER BY ID(n)
+WITH collect(n) AS nodes
+RETURN flex.exp.pagerankv({nodes: nodes}) AS res;
+```
+
+### Example 2: Custom weight attribute
+```cypher
+MATCH (n)
+WITH n ORDER BY ID(n)
+WITH collect(n) AS nodes
+RETURN flex.exp.pagerankv({nodes: nodes, weightAttribute: 'strength'}) AS res;
+```
+
+## Notes
+- **Edge weights:** when `weightAttribute` is present and numeric, it is used to distribute rank proportionally across outgoing edges.
+- **Dangling nodes:** nodes with no outgoing edges distribute their rank uniformly to all nodes.
+
+## See Also
+- [docs/README.md](../README.md)

--- a/src/exp-algo/pagerankv.js
+++ b/src/exp-algo/pagerankv.js
@@ -1,0 +1,233 @@
+/*
+ * Copyright FalkorDB Ltd. 2023 - present
+ */
+
+/**
+ * PageRank (experimental) with optional edge weight consideration.
+ *
+ * Pragmatic UDF-oriented implementation:
+ * - builds directed adjacency from a provided node set using graph.traverse
+ * - runs power-iteration until convergence or maxIterations
+ * - supports weighted transitions based on an edge weight attribute
+ */
+
+// Ensure shared helpers are loaded when running under Node/Jest.
+// QuickJS/FalkorDB will ignore this because 'module' is not defined.
+// istanbul ignore next
+if (typeof module !== 'undefined' && module.exports) {
+  require('./community');
+}
+
+(function initExpPageRankV() {
+  const g =
+    // istanbul ignore next
+    typeof globalThis !== 'undefined'
+      ? globalThis
+      : // istanbul ignore next
+        typeof self !== 'undefined'
+        ? self
+        : this;
+
+  if (!g.__flexExpAlgo) {
+    g.__flexExpAlgo = Object.create(null);
+  }
+
+  const exp = g.__flexExpAlgo;
+
+  function mapToObject(map) {
+    const obj = Object.create(null);
+    for (const [k, v] of map.entries()) {
+      obj[String(k)] = v;
+    }
+    return obj;
+  }
+
+  /**
+   * Weighted PageRank over a node set.
+   *
+   * @param {object} params
+   * @param {any[]} params.nodes Input nodes (objects), must include `id` by default.
+   * @param {string|string[]} [params.direction='both'] Traversal direction(s) used to build adjacency.
+   * @param {number} [params.maxEdgesPerNode=Infinity] Safety cap per node traversal.
+   * @param {number} [params.damping=0.85] Damping factor (alpha).
+   * @param {number} [params.maxIterations=50] Maximum power-iterations.
+   * @param {number} [params.tolerance=1e-8] L1 delta threshold for convergence.
+   * @param {string|string[]} [params.weightAttribute='weight'] Edge attribute(s) to read weight from.
+   * @param {number} [params.defaultWeight=1] Weight to use when attribute is missing.
+   * @param {number} [params.minWeight=0] Lower bound clamp for weights.
+   * @param {(node:any)=>any} [params.getNodeId]
+   * @param {boolean} [params.debug=false]
+   *
+   * @returns {{ scores: Object, iterations: number, converged: boolean, debug?: Object }}
+   */
+  function pagerankv({
+    nodes,
+    direction = 'both',
+    maxEdgesPerNode = Infinity,
+    damping = 0.85,
+    maxIterations = 50,
+    tolerance = 1e-8,
+    weightAttribute = 'weight',
+    defaultWeight = 1,
+    minWeight = 0,
+    getNodeId = exp.defaultGetNodeId,
+    debug = false,
+  }) {
+    const keys = Array.isArray(weightAttribute) ? weightAttribute : [weightAttribute];
+
+    const getWeight = (edge) =>
+      exp.getEdgeWeight(edge, {
+        keys,
+        defaultValue: defaultWeight,
+        minValue: minWeight,
+      });
+
+    const built = exp.buildDirectedAdjacency({
+      nodes,
+      direction,
+      maxEdgesPerNode,
+      getNodeId,
+      getWeight,
+      debug,
+    });
+
+    const nodeIds = built.nodeIds;
+    const adjacency = built.adjacency;
+    const n = nodeIds.length;
+
+    if (n === 0) {
+      return { scores: Object.create(null), iterations: 0, converged: true };
+    }
+
+    const clampDamping =
+      typeof damping === 'number' && Number.isFinite(damping)
+        ? Math.min(1, Math.max(0, damping))
+        : 0.85;
+
+    const maxIter =
+      typeof maxIterations === 'number' && Number.isFinite(maxIterations) && maxIterations > 0
+        ? Math.floor(maxIterations)
+        : 50;
+
+    const tol =
+      typeof tolerance === 'number' && Number.isFinite(tolerance) && tolerance >= 0
+        ? tolerance
+        : 1e-8;
+
+    const index = new Map();
+    for (let i = 0; i < n; i++) {
+      index.set(nodeIds[i], i);
+    }
+
+    const outWeight = new Array(n);
+    for (let i = 0; i < n; i++) {
+      const id = nodeIds[i];
+      const row = adjacency.get(id);
+      let s = 0;
+      if (row) {
+        for (const w of row.values()) {
+          if (w > 0) s += w;
+        }
+      }
+      outWeight[i] = s;
+    }
+
+    // Initial uniform distribution.
+    let rank = new Array(n);
+    for (let i = 0; i < n; i++) rank[i] = 1 / n;
+
+    let next = new Array(n);
+
+    const base = (1 - clampDamping) / n;
+
+    let converged = false;
+    let iterations = 0;
+    const deltas = debug ? [] : null;
+
+    for (let iter = 0; iter < maxIter; iter++) {
+      iterations = iter + 1;
+
+      for (let i = 0; i < n; i++) next[i] = base;
+
+      let danglingMass = 0;
+
+      for (let i = 0; i < n; i++) {
+        const r = rank[i];
+        const ow = outWeight[i];
+        if (!(ow > 0)) {
+          danglingMass += r;
+          continue;
+        }
+
+        const srcId = nodeIds[i];
+        const row = adjacency.get(srcId);
+        if (!row) {
+          danglingMass += r;
+          continue;
+        }
+
+        const factor = (clampDamping * r) / ow;
+
+        for (const [dstId, w] of row.entries()) {
+          if (!(w > 0)) continue;
+          const j = index.get(dstId);
+          if (typeof j !== 'number') continue;
+          next[j] += factor * w;
+        }
+      }
+
+      if (danglingMass > 0) {
+        const add = (clampDamping * danglingMass) / n;
+        for (let j = 0; j < n; j++) next[j] += add;
+      }
+
+      let delta = 0;
+      for (let j = 0; j < n; j++) {
+        delta += Math.abs(next[j] - rank[j]);
+      }
+
+      if (deltas) deltas.push(delta);
+
+      // swap
+      const tmp = rank;
+      rank = next;
+      next = tmp;
+
+      if (delta <= tol) {
+        converged = true;
+        break;
+      }
+    }
+
+    const scores = new Map();
+    for (let i = 0; i < n; i++) {
+      scores.set(nodeIds[i], rank[i]);
+    }
+
+    const out = {
+      scores: mapToObject(scores),
+      iterations,
+      converged,
+    };
+
+    if (debug) {
+      out.debug = {
+        adjacency: built.debug,
+        deltas,
+      };
+    }
+
+    return out;
+  }
+
+  falkor.register('exp.pagerankv', pagerankv);
+
+  // Conditional Export for Jest
+  // QuickJS/FalkorDB will ignore this because 'module' is not defined.
+  // istanbul ignore next
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = {
+      pagerankv,
+    };
+  }
+})();

--- a/tests/exp-algo/pagerankv.test.js
+++ b/tests/exp-algo/pagerankv.test.js
@@ -1,0 +1,81 @@
+/*
+ * Copyright FalkorDB Ltd. 2023 - present
+ */
+
+const { initializeFLEX } = require('../setup');
+const pagerankvModule = require('../../src/exp-algo/pagerankv');
+
+describe('FLEX exp-algo PageRankV Integration Tests', () => {
+  let db, graph;
+
+  beforeAll(async () => {
+    const env = await initializeFLEX('exp_algo_pagerankv');
+    db = env.db;
+    graph = env.graph;
+  });
+
+  afterAll(async () => {
+    if (db) {
+      await db.close();
+    }
+  });
+
+  test('module is importable in Node (conditional export)', () => {
+    expect(typeof pagerankvModule.pagerankv).toBe('function');
+  });
+
+  test('flex.exp.pagerankv considers edge weights (heavier link gives higher score)', async () => {
+    // Make the test idempotent when re-run against the same local DB.
+    await graph.query(`MATCH (n) DETACH DELETE n`);
+
+    // Symmetric-ish graph, except A->B has much larger weight than A->C.
+    await graph.query(`
+      CREATE (a:N {name:'a'}), (b:N {name:'b'}), (c:N {name:'c'})
+      CREATE
+        (a)-[:R {weight:10}]->(b),
+        (a)-[:R {weight:1}]->(c),
+        (b)-[:R {weight:1}]->(a),
+        (c)-[:R {weight:1}]->(a)
+    `);
+
+    const idRows = await graph.query(`
+      MATCH (n:N)
+      RETURN ID(n) AS id, n.name AS name
+      ORDER BY id
+    `);
+
+    const nameToId = new Map();
+    for (const row of idRows.data) {
+      nameToId.set(row.name, String(row.id));
+    }
+
+    const out = await graph.query(`
+      MATCH (n:N)
+      WITH n ORDER BY ID(n)
+      WITH collect(n) AS nodes
+      RETURN flex.exp.pagerankv({nodes: nodes, maxIterations: 200, tolerance: 1e-12}) AS res
+    `);
+
+    const res = out.data[0].res;
+    expect(res).toHaveProperty('scores');
+    expect(res).toHaveProperty('iterations');
+    expect(res).toHaveProperty('converged');
+
+    const scores = res.scores;
+
+    const a = scores[nameToId.get('a')];
+    const b = scores[nameToId.get('b')];
+    const c = scores[nameToId.get('c')];
+
+    expect(typeof a).toBe('number');
+    expect(typeof b).toBe('number');
+    expect(typeof c).toBe('number');
+
+    // Weight should push more rank from A to B than to C.
+    expect(b).toBeGreaterThan(c);
+
+    const sum = a + b + c;
+    expect(sum).toBeGreaterThan(0.999);
+    expect(sum).toBeLessThan(1.001);
+  });
+});


### PR DESCRIPTION
Adds experimental weighted PageRank vector scoring as `flex.exp.pagerankv`.

- Supports weighted transitions via `weightAttribute` (default: `weight`).
- Adds `buildDirectedAdjacency` helper for directed adjacency construction.
- Includes integration test and documentation.

Testing:
- `FLEX_USE_LOCAL_FALKORDB=1 npm test`

Co-Authored-By: Warp <agent@warp.dev>