### PR TITLE
exp.pagerankv: add NetworkX-style personalization support

### DIFF
--- a/docs/exp-algo/pagerankv.md
+++ b/docs/exp-algo/pagerankv.md
@@ -13,7 +13,7 @@ It supports **weighted transitions**: if an edge has a numeric weight attribute 
 
 ## Syntax
 ```cypher
-flex.exp.pagerankv({nodes: nodes, direction: 'both', damping: 0.85, maxIterations: 50, tolerance: 1e-8})
+flex.exp.pagerankv({nodes: nodes, direction: 'both', damping: 0.85, maxIterations: 50, tolerance: 1e-8, personalization: {'42': 1}})
 ```
 
 ## Parameters
@@ -28,6 +28,8 @@ flex.exp.pagerankv({nodes: nodes, direction: 'both', damping: 0.85, maxIteration
 | `weightAttribute` | `string \| list<string>` | No | Relationship property name(s) to read weights from. Default: `'weight'`. |
 | `defaultWeight` | `float` | No | Weight to use when no attribute is present. Default: `1`. |
 | `minWeight` | `float` | No | Clamp lower bound for weights. Default: `0`. |
+| `personalization` | `map<string, float>` | No | Personalized restart weights keyed by node id. Keys may be a subset of supplied nodes. Values are normalized over in-graph keys. Missing nodes receive zero. Default: uniform distribution over all nodes. |
+| `dangling` | `map<string, float>` | No | Redistribution weights for dangling nodes (nodes with no outgoing edges). Values are normalized over in-graph keys. Default: `personalization` (or uniform when `personalization` is omitted). |
 | `debug` | `boolean` | No | When `true`, returns extra debug information (adjacency stats + per-iteration deltas). Default: `false`. |
 
 ## Returns
@@ -64,9 +66,25 @@ WITH collect(n) AS nodes
 RETURN flex.exp.pagerankv({nodes: nodes, weightAttribute: 'strength'}) AS res;
 ```
 
+### Example 3: Personalized PageRank (seed-biased restarts)
+```cypher
+MATCH (n:N)
+WITH n ORDER BY ID(n)
+WITH collect(n) AS nodes
+RETURN flex.exp.pagerankv({
+  nodes: nodes,
+  personalization: {
+    '42': 0.7,
+    '87': 0.3
+  }
+}) AS res;
+```
+
 ## Notes
 - **Edge weights:** when `weightAttribute` is present and numeric, it is used to distribute rank proportionally across outgoing edges.
-- **Dangling nodes:** nodes with no outgoing edges distribute their rank uniformly to all nodes.
+- **Personalization normalization:** `personalization` does not need to sum to `1`; in-graph values are normalized automatically.
+- **Dangling nodes:** when `dangling` is omitted, dangling mass is redistributed using the personalization distribution (uniform when no personalization is provided).
+- **Validation:** `personalization` and `dangling` values must be finite and non-negative, and at least one in-graph value must be positive.
 
 ## See Also
 - [docs/README.md](../README.md)

--- a/src/exp-algo/pagerankv.js
+++ b/src/exp-algo/pagerankv.js
@@ -42,6 +42,54 @@ if (typeof module !== 'undefined' && module.exports) {
     return obj;
   }
 
+  function normalizeNodeWeightMap(raw, { n, stableIndex, name }) {
+    if (raw == null) {
+      const uniform = new Array(n);
+      for (let i = 0; i < n; i++) uniform[i] = 1 / n;
+      return uniform;
+    }
+
+    const isMap = raw instanceof Map;
+    const isObject = !isMap && typeof raw === 'object' && !Array.isArray(raw);
+    if (!isObject && !isMap) {
+      throw new TypeError(`pagerankv: \`${name}\` must be an object map or Map`);
+    }
+
+    const vec = new Array(n);
+    for (let i = 0; i < n; i++) vec[i] = 0;
+
+    const addEntry = (k, v) => {
+      if (typeof v !== 'number' || !Number.isFinite(v)) {
+        throw new TypeError(`pagerankv: \`${name}\` values must be finite numbers`);
+      }
+      if (v < 0) {
+        throw new RangeError(`pagerankv: \`${name}\` values must be >= 0`);
+      }
+
+      const sid = exp.stableKeyPart(k);
+      const idx = stableIndex.get(sid);
+      if (typeof idx !== 'number') return;
+      vec[idx] += v;
+    };
+
+    if (isMap) {
+      for (const [k, v] of raw.entries()) addEntry(k, v);
+    } else {
+      for (const [k, v] of Object.entries(raw)) addEntry(k, v);
+    }
+
+    let sum = 0;
+    for (let i = 0; i < n; i++) sum += vec[i];
+    if (!(sum > 0)) {
+      throw new TypeError(
+        `pagerankv: \`${name}\` must assign positive weight to at least one input node`
+      );
+    }
+
+    for (let i = 0; i < n; i++) vec[i] /= sum;
+    return vec;
+  }
+
   /**
    * Weighted PageRank over a node set.
    *
@@ -55,6 +103,8 @@ if (typeof module !== 'undefined' && module.exports) {
    * @param {string|string[]} [params.weightAttribute='weight'] Edge attribute(s) to read weight from.
    * @param {number} [params.defaultWeight=1] Weight to use when attribute is missing.
    * @param {number} [params.minWeight=0] Lower bound clamp for weights.
+   * @param {Object<string,number>|Map<any,number>} [params.personalization]
+   * @param {Object<string,number>|Map<any,number>} [params.dangling]
    * @param {(node:any)=>any} [params.getNodeId]
    * @param {boolean} [params.debug=false]
    *
@@ -70,6 +120,8 @@ if (typeof module !== 'undefined' && module.exports) {
     weightAttribute = 'weight',
     defaultWeight = 1,
     minWeight = 0,
+    personalization = null,
+    dangling = null,
     getNodeId = exp.defaultGetNodeId,
     debug = false,
   }) {
@@ -115,8 +167,11 @@ if (typeof module !== 'undefined' && module.exports) {
         : 1e-8;
 
     const index = new Map();
+    const stableIndex = new Map();
     for (let i = 0; i < n; i++) {
-      index.set(nodeIds[i], i);
+      const id = nodeIds[i];
+      index.set(id, i);
+      stableIndex.set(exp.stableKeyPart(id), i);
     }
 
     const outWeight = new Array(n);
@@ -138,7 +193,20 @@ if (typeof module !== 'undefined' && module.exports) {
 
     let next = new Array(n);
 
-    const base = (1 - clampDamping) / n;
+    const personalizationVector = normalizeNodeWeightMap(personalization, {
+      n,
+      stableIndex,
+      name: 'personalization',
+    });
+
+    const danglingVector =
+      dangling == null
+        ? personalizationVector
+        : normalizeNodeWeightMap(dangling, {
+            n,
+            stableIndex,
+            name: 'dangling',
+          });
 
     let converged = false;
     let iterations = 0;
@@ -147,7 +215,7 @@ if (typeof module !== 'undefined' && module.exports) {
     for (let iter = 0; iter < maxIter; iter++) {
       iterations = iter + 1;
 
-      for (let i = 0; i < n; i++) next[i] = base;
+      for (let i = 0; i < n; i++) next[i] = (1 - clampDamping) * personalizationVector[i];
 
       let danglingMass = 0;
 
@@ -177,8 +245,8 @@ if (typeof module !== 'undefined' && module.exports) {
       }
 
       if (danglingMass > 0) {
-        const add = (clampDamping * danglingMass) / n;
-        for (let j = 0; j < n; j++) next[j] += add;
+        const add = clampDamping * danglingMass;
+        for (let j = 0; j < n; j++) next[j] += add * danglingVector[j];
       }
 
       let delta = 0;

--- a/tests/exp-algo/pagerankv.test.js
+++ b/tests/exp-algo/pagerankv.test.js
@@ -78,4 +78,115 @@ describe('FLEX exp-algo PageRankV Integration Tests', () => {
     expect(sum).toBeGreaterThan(0.999);
     expect(sum).toBeLessThan(1.001);
   });
+
+  test('flex.exp.pagerankv supports NetworkX-style personalization (subset keys + normalization)', async () => {
+    await graph.query(`MATCH (n) DETACH DELETE n`);
+
+    // Directed 3-cycle. Without personalization, scores would be uniform.
+    await graph.query(`
+      CREATE (a:N {name:'a'}), (b:N {name:'b'}), (c:N {name:'c'})
+      CREATE
+        (a)-[:R {weight:1}]->(b),
+        (b)-[:R {weight:1}]->(c),
+        (c)-[:R {weight:1}]->(a)
+    `);
+
+    const idRows = await graph.query(`
+      MATCH (n:N)
+      RETURN ID(n) AS id, n.name AS name
+      ORDER BY id
+    `);
+
+    const nameToId = new Map();
+    for (const row of idRows.data) {
+      nameToId.set(row.name, String(row.id));
+    }
+
+    const aId = nameToId.get('a');
+
+    const out = await graph.query(`
+      MATCH (n:N)
+      WITH n ORDER BY ID(n)
+      WITH collect(n) AS nodes
+      RETURN flex.exp.pagerankv({
+        nodes: nodes,
+        maxIterations: 300,
+        tolerance: 1e-12,
+        personalization: flex.map.fromPairs([['${aId}', 10]])
+      }) AS res
+    `);
+
+    const res = out.data[0].res;
+    const scores = res.scores;
+
+    const a = scores[nameToId.get('a')];
+    const b = scores[nameToId.get('b')];
+    const c = scores[nameToId.get('c')];
+
+    expect(a).toBeGreaterThan(b);
+    expect(b).toBeGreaterThan(c);
+
+    const sum = a + b + c;
+    expect(sum).toBeGreaterThan(0.999);
+    expect(sum).toBeLessThan(1.001);
+  });
+
+  test('flex.exp.pagerankv uses personalization for dangling redistribution by default', async () => {
+    await graph.query(`MATCH (n) DETACH DELETE n`);
+
+    // Node b is dangling (no outgoing edges).
+    await graph.query(`
+      CREATE (a:N {name:'a'}), (b:N {name:'b'})
+      CREATE (a)-[:R {weight:1}]->(b)
+    `);
+
+    const idRows = await graph.query(`
+      MATCH (n:N)
+      RETURN ID(n) AS id, n.name AS name
+      ORDER BY id
+    `);
+
+    const nameToId = new Map();
+    for (const row of idRows.data) {
+      nameToId.set(row.name, String(row.id));
+    }
+
+    const aId = nameToId.get('a');
+    const bId = nameToId.get('b');
+
+    const defaultDanglingOut = await graph.query(`
+      MATCH (n:N)
+      WITH n ORDER BY ID(n)
+      WITH collect(n) AS nodes
+      RETURN flex.exp.pagerankv({
+        nodes: nodes,
+        maxIterations: 300,
+        tolerance: 1e-12,
+        personalization: flex.map.fromPairs([['${aId}', 1]])
+      }) AS res
+    `);
+
+    const defaultScores = defaultDanglingOut.data[0].res.scores;
+    const aDefault = defaultScores[aId];
+    const bDefault = defaultScores[bId];
+    expect(aDefault).toBeGreaterThan(bDefault);
+
+    const explicitDanglingOut = await graph.query(`
+      MATCH (n:N)
+      WITH n ORDER BY ID(n)
+      WITH collect(n) AS nodes
+      RETURN flex.exp.pagerankv({
+        nodes: nodes,
+        maxIterations: 300,
+        tolerance: 1e-12,
+        personalization: flex.map.fromPairs([['${aId}', 1]]),
+        dangling: flex.map.fromPairs([['${bId}', 1]])
+      }) AS res
+    `);
+
+    const explicitScores = explicitDanglingOut.data[0].res.scores;
+    const aExplicit = explicitScores[aId];
+    const bExplicit = explicitScores[bId];
+    expect(bExplicit).toBeGreaterThan(aExplicit);
+  });
 });


### PR DESCRIPTION
## Summary
- add optional personalization and dangling parameters to flex.exp.pagerankv
- implement normalization and validation semantics aligned with NetworkX pagerank(personalization=..., dangling=...)
- use personalization for restart probability and default dangling redistribution
- add integration coverage for subset personalization normalization and explicit dangling overrides
- update pagerankv docs with API, behavior notes, and examples

## Validation
- FLEX_USE_LOCAL_FALKORDB=1 npm run build
- FLEX_USE_LOCAL_FALKORDB=1 npx jest --verbose --runInBand --forceExit tests/exp-algo/pagerankv.test.js

Addresses #122.

Conversation: https://app.warp.dev/conversation/cb21495e-9522-48a8-a7f9-7aca36b10bda

Co-Authored-By: Oz <oz-agent@warp.dev>
